### PR TITLE
fix: Update module path to clerk/hivemind

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/clerkinc/hivemind
+module github.com/clerk/hivemind
 
 go 1.12
 


### PR DESCRIPTION
We recently renamed our GH org to clerk.

Note: This is a potentially breaking change.